### PR TITLE
Feature/add in and out plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 result_*
 *.npy
 *.npz
+.png
+.pdf

--- a/autoencoder_by_chainer/autoencoder.py
+++ b/autoencoder_by_chainer/autoencoder.py
@@ -345,6 +345,10 @@ def training_stacked_autoencoder(
 
     return model
 
+# **********************************************
+# Viasualization
+# **********************************************
+
 # 重みの可視化
 def weight_plot(
         model, plot_num, select_layer='encoder',
@@ -419,6 +423,10 @@ def bias_plot(model, select_layer='encoder',
 # **********************************************
 def main():
  
+    # -------------------------------------
+    # 設定
+    # -------------------------------------
+
     # コマンドライン引数を読み込み
     # 引数が'-1'なら学習しない
     args = sys.argv
@@ -431,23 +439,36 @@ def main():
     save_dir = '../output/result_autoencoder'
     os.makedirs(save_dir, exist_ok=True)
 
+    # -------------------------------------
+    # データの準備
+    # -------------------------------------
+
+    # 指定した数字データを抜くための変数
+    number = 0
+
     # MNISTデータの読み込み
     train, test = chainer.datasets.get_mnist()
-    
-    # データとラベルに切り分け(ラベルは不要)
-    # 指定したnumber(ラベル)で抜き取り
-    number = 0
+
+    # データとラベルを取得
     train_data, train_label = train._datasets
-    train_data = train_data[train_label == number]
     test_data, test_label = test._datasets
+    
+    # 学習データ: 特定の番号のみ抽出したデータを用いる
+    train_data = train_data[train_label == number]
+
+    # テストデータ: ト特定の番号と適当なデータを合計で10個取得
     test_data_n  = test_data[test_label == number]
     test_label_n = test_label[test_label == number]
     test_data  = np.concatenate((test_data_n[0:5],  test_data[0:5]))
     test_label = np.concatenate((test_label_n[0:5], test_label[0:5]))
 
-    # 学習の条件
-    # エポックとミニバッチサイズ
+    # -------------------------------------
+    # 学習の準備
+    # -------------------------------------
+
+    # エポック
     epoch = 100
+    # ミニバッチサイズ
     batchsize = 50
     # 隠れ層のユニット数
     hidden = 10
@@ -455,7 +476,10 @@ def main():
     # 作成するモデルの保存先+名前
     model_path = os.path.join(save_dir, 'autoencoder_sample.npz')
 
+    # -------------------------------------
     # AutoEncoderの学習
+    # -------------------------------------
+
     # コマンドライン引数が'-1'の場合学習しない
     if train_mode:
         # Autoencoderの学習
@@ -467,22 +491,45 @@ def main():
         model = Autoencoder(784, hidden)
         serializers.load_npz(model_path, model)
 
-    # 再構成を行う
-    # AutoEncoderの再構成を行うクラスを定義
+    # -------------------------------------
+    # 再構成
+    # -------------------------------------
+
+    # 再構成を行うクラスを定義
     ar = Reconst(model)
+    # 再構成を実行
     feat_train, reconst_train, err_train = ar(train_data)
     feat_test,  reconst_test,  err_test  = ar(test_data)
 
     # しきい値の計算(u+3sigma)
     mn, std, th = ar.err2threshold(err_train, 3)
-    print("th: ", th)
-
-    #print(labels[0:9])
-    print("label: ",test_label)
-
+    # しきい値を用いたときの異常判定
     result = ar.judgment(err_test, th)
+
+    print("label: ",test_label)
     print("result: ", result)
     print("errors: ", err_test)
+
+    # -------------------------------------
+    # 可視化
+    # -------------------------------------
+
+    # 保存先ディレクトリの生成
+    save_dir = os.path.join(save_dir, 'img')
+    os.makedirs(save_dir, exist_ok=True)
+    
+    # 1次元に並んだデータをreshapeするサイズ
+    reshape_size = [28, 28]
+    for (save_name, dataset) in zip(
+            ['input', 'reconst'], [test_data, reconst_test]):
+        # 入出力をplot
+        for i, d in enumerate(dataset):
+            save_path = os.path.join(
+                    save_dir,
+                    '_'.join([save_name, str(i+1)]) + '.png')
+            d = d.reshape(reshape_size)
+            plt.imshow(d, cmap='gray')
+            plt.savefig(save_path)
 
     # encoderの重みを可視化
     save_path = os.path.join(save_dir, 'encoder_weight.png')


### PR DESCRIPTION
入出力を可視化（画像を保存）するようにしました。
大きな追加点は以下の部分です。

```
 # 1次元に並んだデータをreshapeするサイズ
    reshape_size = [28, 28]
    for (save_name, dataset) in zip(
            ['input', 'reconst'], [test_data, reconst_test]):
        # 入出力をplot
        for i, d in enumerate(dataset):
            save_path = os.path.join(
                    save_dir,
                    '_'.join([save_name, str(i+1)]) + '.png')
            d = d.reshape(reshape_size)
            plt.imshow(d, cmap='gray')
            plt.savefig(save_path)
```

このコードはあまり本質的な部分ではないと考えて関数化までしていません。
実際は関数化したほうが便利かもしれませんが...

現状はデモの動作として十分だと思います。